### PR TITLE
add bs4 to requirements

### DIFF
--- a/custom_components/audiconnect/manifest.json
+++ b/custom_components/audiconnect/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/cyr-ius/hass-audiconnect",
   "issue_tracker": "https://github.com/cyr-ius/hass-audiconnect/issues",
-  "requirements": [],
+  "requirements": ["bs4"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},


### PR DESCRIPTION
bs4 should be in the requirements so that home-assistant pulls it if it's missing.