### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -46,6 +46,11 @@ SENSOR_TYPES: tuple[AudiSensorDescription, ...] = (
         translation_key="maintenance_interval_distance_to_oil_change",
     ),
     AudiSensorDescription(
+        icon="mdi:ev-station",
+        key="charging_state",
+        translation_key="charging_state",
+    ),
+    AudiSensorDescription(
         icon="mdi:speedometer",
         native_unit_of_measurement="km",
         key="climatisation_target_temp",


### PR DESCRIPTION
Add charging_state as sensor because it can have multilpe values like 'charging', 'error', etc. As a switch those values aren't visible.