### PR TITLE
Update sensor.py - add climatisation_state

### DIFF
--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -24,6 +24,11 @@ SENSOR_TYPES: tuple[AudiSensorDescription, ...] = (
         translation_key="last_access",
     ),
     AudiSensorDescription(
+        icon="mdi:air-conditioner",
+        key="climatisation_state",
+        translation_key="climatisation_state",
+    ),
+    AudiSensorDescription(
         icon="mdi:update",
         key="last_update_time",
         device_class=dc.TIMESTAMP,


### PR DESCRIPTION
add climatisation_state also as a sensor because it can have a values like 'heating', 'cooling' or 'error' which is not shown as a switch