### PR TITLE
Update binary_sensor.py - plug lock

### DIFF
--- a/custom_components/audiconnect/binary_sensor.py
+++ b/custom_components/audiconnect/binary_sensor.py
@@ -231,8 +231,8 @@ SENSOR_TYPES: tuple[AudiBinarySensorDescription, ...] = (
     AudiBinarySensorDescription(
         icon="mdi:power-plug",
         key="plug_lock",
-        device_class=dc.PLUG,
-        value_fn=lambda x: False if x == "unlocked" else True,
+        device_class=dc.LOCK,
+        value_fn=lambda x: False if x == "locked" else True,
     ),
     AudiBinarySensorDescription(
         key="preheater_active",


### PR DESCRIPTION
Plug lock should be of device class LOCK. It was also switched (locked when unlocked / unlocked when locked).