### PR TITLE
Update sensor.py - remove plug state

### DIFF
--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -194,12 +194,6 @@ SENSOR_TYPES: tuple[AudiSensorDescription, ...] = (
         translation_key="state_of_charge",
     ),
     AudiSensorDescription(
-        icon="mdi:power-plug",
-        key="plug_state",
-        device_class=dc.POWER_FACTOR,
-        translation_key="plug_state",
-    ),
-    AudiSensorDescription(
         icon="mdi:battery-charging",
         key="remaining_charging_time",
         value_fn=lambda x: "n/a"


### PR DESCRIPTION
Remove plug_state as sensor. This should be a binary_sensor.
Added as binary_sensor in this pull request: https://github.com/cyr-ius/hass-audiconnect/pull/53
Sensor could be removed after binary_sensor is added (pull 53).

Also, this sensor doesn't have the correct device_class. So if pull isn't accepted. Maybe change the device_class.